### PR TITLE
Fix Dispose method in RuntimeSquare. Add REPLACESTR method in Expression Evaluator

### DIFF
--- a/Reportman.Designer/RuntimeResize.cs
+++ b/Reportman.Designer/RuntimeResize.cs
@@ -278,8 +278,11 @@ namespace Reportman.Designer
         }
         protected override void Dispose(bool disposing)
         {
-            MyPen.Dispose();
-            MyBrush.Dispose();
+            if (disposing)
+            {
+                MyPen.Dispose();
+                MyBrush.Dispose();
+            }                
             base.Dispose(disposing);
         }
         protected override void OnPaint(PaintEventArgs e)

--- a/Reportman.Drawing.Windows/GraphicUtils.cs
+++ b/Reportman.Drawing.Windows/GraphicUtils.cs
@@ -9,7 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using static ICSharpCode.SharpZipLib.Zip.ExtendedUnixData;
 
-namespace Reportman.Drawing
+namespace Reportman.Drawing.Windows
 {
     public class GraphicUtils
     {

--- a/Reportman.Reporting/EvalFunctions.cs
+++ b/Reportman.Reporting/EvalFunctions.cs
@@ -952,4 +952,45 @@ namespace Reportman.Reporting
             return aresult;
         }
     }
+    class IdenReplaceStr : IdenFunction
+    {
+        public IdenReplaceStr(Evaluator eval)
+            : base(eval)
+        {
+            SetParamCount(3);
+            Name = "REPLACESTR";
+            FModel = "function REPLACESTR(s:string;old:string;new:string):string";
+        }
+        protected override Variant GetValue()
+        {
+            Variant aresult = new Variant();           
+            if (Params[0].VarType != VariantType.Null)
+            {
+                if (Params[0].VarType != VariantType.String)
+                {
+                    throw new NamedException(Translator.TranslateStr(438), "REPLACESTR");
+                }
+                string s = Params[0].AsString;
+                if (Params[1].VarType != VariantType.String)
+                {
+                    throw new NamedException(Translator.TranslateStr(438), "REPLACESTR");
+                }
+                string oldstr = Params[1].AsString;
+                if (Params[2].VarType != VariantType.String)
+                {
+                    throw new NamedException(Translator.TranslateStr(438), "REPLACESTR");
+                }
+                string newstr = Params[2].AsString;
+                if (oldstr != null && newstr != null && oldstr.Length > 0)
+                {
+                    aresult = s.Replace(oldstr, newstr);
+                }
+                else
+                {
+                    aresult = s;
+                }
+            }
+            return aresult;
+        }
+    }
 }

--- a/Reportman.Reporting/Evaluator.cs
+++ b/Reportman.Reporting/Evaluator.cs
@@ -968,6 +968,7 @@ namespace Reportman.Reporting
             FIdentifierList.Add("MOD", new IdenModul(this));
             FIdentifierList.Add("EVALTEXT", new IdenEvalText(this));
             FIdentifierList.Add("NUMTOTEXT", new IdenNumToText(this));
+            FIdentifierList.Add("REPLACESTR", new IdenReplaceStr(this));
         }
 
         /// <summary> 


### PR DESCRIPTION
Added a check for the 'disposing' parameter to ensure that MyPen and MyBrush are only disposed of when appropriate. Without this check the following line in OnPaint event of RunTimeSquare was throwing an exception because MyBrush would be disposed by garbage collector.

`e.Graphics.FillRectangle(MyBrush, new Rectangle(0, 0, Width - 1, Height - 1))`