### PR TITLE
Support Firebird 3.0+ Identity Columns and Metadata Updates

### DIFF
--- a/FirebirdSql.Metadata.Extract/FbCompare.cs
+++ b/FirebirdSql.Metadata.Extract/FbCompare.cs
@@ -1589,8 +1589,9 @@ namespace FirebirdSql.Metadata.Extract
             string checksql = "";
 
             bool hasrelationtype = true;
+            bool hasidentity = OdsVersion >= 12;
 
-            FbExtract.GetTablesSql("", false, false, hasrelationtype, ref sql, ref checksql, ref relsql);
+            FbExtract.GetTablesSql("", false, false, hasrelationtype, hasidentity, ref sql, ref checksql, ref relsql);
 
             DoProgress(0, 0, "Reading destination table checks", "");
             OldDb.Open(OldData, checksql, "CHECKS");


### PR DESCRIPTION
Updated `FirebirdSql.Metadata.Extract` to support newer Firebird versions.
Key changes:
1.  **Identity Columns:** Implemented extraction of `GENERATED {ALWAYS | BY DEFAULT} AS IDENTITY` with `START WITH` and `INCREMENT BY` options.
2.  **Global Temporary Tables:** Fixed detection of `PRESERVE ROWS` type and added correct `ON COMMIT` clause generation.
3.  **Identifiers:** Increased supported identifier length from 31 to 63 characters.
4.  **Data Types:** Added support for `TIME WITH TIME ZONE`.
5.  **Metadata Querying:** Updated `GetTablesSql` to conditionally fetch identity-related columns (`RDB$IDENTITY_TYPE`, `RDB$GENERATOR_NAME`, etc.) based on ODS version.
6.  **Generator Exclusion:** Excluded internal identity generators (`RDB$SYSTEM_FLAG = 6`) from explicit generator extraction.

---
*PR created automatically by Jules for task [2578238495676051413](https://jules.google.com/task/2578238495676051413) started by @tonimartir*